### PR TITLE
Fixes #5.

### DIFF
--- a/search.php
+++ b/search.php
@@ -96,8 +96,8 @@ foreach($stack_results as $name => $stack)
     if (strlen($desc) == 100)
       $desc .= "...";
   }
-  $maintainers = format_names($pkg['maintainers']);
-  $authors = format_names($pkg['authors']);
+  $maintainers = format_names($stack['maintainers']);
+  $authors = format_names($stack['authors']);
   $maintainers_and_authors = $maintainers + $authors;
   echo '<tr><td class="pkgname"><a href="details.php?distro=' . urlencode($distro) . '&name=' . urlencode($name) . '">' . $name . '</a></td><td>' . implode(', ', $maintainers_and_authors) . '</td><td>' . htmlentities($desc) . '</td></tr>';
   echo "\n";


### PR DESCRIPTION
I haven't been able to do system test this change, but I'm kind of sure this will fix #5 with the reasoning below.

**A bit more observation**
The last iterated pkg per each ROS distro (as of 20170126):
- zeroconf_msgs for IK. Maintainer: Daniel Stonier
- zbar_ros      for J.	Maintainer: Paul Bovbel

You can search by a random keyword with each ROS distro, and the maintainer above appears at the metapackage search result for any keyword (as far as I tested).

**Solution in this commit**
Before the line changed in this commit, "$pkg" variable was the last time used at this line https://github.com/ros-infrastructure/rosbrowse/blob/df56148ec94ce51975d5c6f2c40494428fcca050/search.php#L39, which is the package iteration happened. So it's likely that $pkg still keeps the result from the last iterated package, which is what we observed above.